### PR TITLE
fix: replace static kube-dns Endpoints with selector-based Service

### DIFF
--- a/roles/gen3/tasks/gen3.yml
+++ b/roles/gen3/tasks/gen3.yml
@@ -71,16 +71,6 @@
   register: gen3_db_creds_apply
   changed_when: '"unchanged" not in gen3_db_creds_apply.stdout'
 
-- name: Get rke2-coredns pod IP
-  tags: [kubedns]
-  command: >
-    bin/kubectl get endpoints rke2-coredns-rke2-coredns -n kube-system
-    -o jsonpath='{.subsets[0].addresses[0].ip}'
-  args:
-    chdir: /home/{{ gen3.user }}
-  register: coredns_ip
-  changed_when: false
-
 - name: Apply kube-dns alias
   tags: [kubedns]
   command: bin/kubectl apply -f -
@@ -93,21 +83,11 @@
         name: kube-dns
         namespace: kube-system
       spec:
+        selector:
+          k8s-app: kube-dns
         ports:
         - {name: udp-53, port: 53, protocol: UDP, targetPort: 53}
         - {name: tcp-53, port: 53, protocol: TCP, targetPort: 53}
-      ---
-      apiVersion: v1
-      kind: Endpoints
-      metadata:
-        name: kube-dns
-        namespace: kube-system
-      subsets:
-      - addresses:
-        - ip: {{ coredns_ip.stdout }}
-        ports:
-        - {name: udp-53, port: 53, protocol: UDP}
-        - {name: tcp-53, port: 53, protocol: TCP}
   register: kubedns_apply
   changed_when: '"unchanged" not in kubedns_apply.stdout'
 


### PR DESCRIPTION
## Summary

- The `kube-dns` alias in `kube-system` was created with a manually-managed `Endpoints` object that hardcoded the CoreDNS pod IP at deploy time
- After rebooting all RKE2 nodes, CoreDNS pods restart with new IPs — the stale `Endpoints` broke in-cluster DNS, causing `revproxy` to return 502 to the portal
- Replaced the two-task block (dynamic IP lookup + manual `Endpoints`) with a single selector-based `Service` (`k8s-app: kube-dns`); Kubernetes now auto-manages `Endpoints` and keeps them current through any reboot

## Test plan

- [ ] Run `ansible-playbook -i inventory.yaml gen3.yml --tags kubedns` — should apply with no errors
- [ ] `kubectl get endpoints kube-dns -n kube-system` — should show live CoreDNS pod IPs
- [ ] `kubectl rollout restart deployment -n gen3` then check portal logs — no more 502 errors on schema fetch
- [ ] After a future node reboot, verify `kubectl get endpoints kube-dns -n kube-system` auto-updates without re-running Ansible

🤖 Generated with [Claude Code](https://claude.com/claude-code)